### PR TITLE
[DEN-376] Update EdgeCast Go SDK version to support Origins with an empty HostHeader field

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -3,7 +3,7 @@ HOSTNAME=github.com
 NAMESPACE=terraform-providers
 NAME=edgecast
 BINARY=terraform-provider-${NAME}
-VERSION=0.5.7
+VERSION=0.5.8
 OS_ARCH=darwin_amd64
 
 default: install

--- a/README.md
+++ b/README.md
@@ -33,7 +33,7 @@ Reference this provider in a Terraform Configuration file (e.g. `main.tf`):
 terraform {
   required_providers {
     edgecast = {
-       version = "0.5.7"
+       version = "0.5.8"
       source  = "Edgio/edgecast"
     }
   }
@@ -110,7 +110,7 @@ Example:
 terraform {
   required_providers {
     edgecast = {
-       version = "0.5.7"
+       version = "0.5.8"
       source  = "Edgio/edgecast"
     }
   }

--- a/Taskfile.yaml
+++ b/Taskfile.yaml
@@ -11,7 +11,7 @@ vars:
   NAMESPACE: terraform-providers
   NAME: edgecast
   BINARY: terraform-provider-{{.NAME}}
-  VERSION: 0.5.7
+  VERSION: 0.5.8
 
 
 includes:

--- a/edgecast/provider.go
+++ b/edgecast/provider.go
@@ -24,7 +24,7 @@ const (
 	idsURLProd       string = "https://id.vdms.io"
 
 	// Version indicates the current version of this provider
-	Version string = "0.5.7"
+	Version string = "0.5.8"
 
 	userAgentFormat = "edgecast/terraform-provider:%s"
 )

--- a/examples/resources/edgecast_customer/main.tf
+++ b/examples/resources/edgecast_customer/main.tf
@@ -4,7 +4,7 @@
 terraform {
   required_providers {
     edgecast = {
-       version = "0.5.7"
+       version = "0.5.8"
       source  = "Edgio/edgecast"
     }
   }

--- a/examples/resources/edgecast_customer_user/main.tf
+++ b/examples/resources/edgecast_customer_user/main.tf
@@ -1,7 +1,7 @@
 terraform {
   required_providers {
     edgecast = {
-       version = "0.5.7"
+       version = "0.5.8"
       source  = "Edgio/edgecast"
     }
   }

--- a/examples/resources/edgecast_dns_group/main.tf
+++ b/examples/resources/edgecast_dns_group/main.tf
@@ -4,7 +4,7 @@
 terraform {
   required_providers {
     edgecast = {
-       version = "0.5.7"
+       version = "0.5.8"
       source  = "Edgio/edgecast"
     }
   }

--- a/examples/resources/edgecast_dns_masterservergroup/main.tf
+++ b/examples/resources/edgecast_dns_masterservergroup/main.tf
@@ -4,7 +4,7 @@
 terraform {
   required_providers {
     edgecast = {
-       version = "0.5.7"
+       version = "0.5.8"
       source  = "Edgio/edgecast"
     }
   }

--- a/examples/resources/edgecast_dns_secondaryzonegroup/main.tf
+++ b/examples/resources/edgecast_dns_secondaryzonegroup/main.tf
@@ -4,7 +4,7 @@
 terraform {
   required_providers {
     edgecast = {
-       version = "0.5.7"
+       version = "0.5.8"
       source  = "Edgio/edgecast"
     }
   }

--- a/examples/resources/edgecast_dns_tsig/main.tf
+++ b/examples/resources/edgecast_dns_tsig/main.tf
@@ -4,7 +4,7 @@
 terraform {
   required_providers {
     edgecast = {
-       version = "0.5.7"
+       version = "0.5.8"
       source  = "Edgio/edgecast"
     }
   }

--- a/examples/resources/edgecast_dns_zone/main.tf
+++ b/examples/resources/edgecast_dns_zone/main.tf
@@ -4,7 +4,7 @@
 terraform {
   required_providers {
     edgecast = {
-       version = "0.5.7"
+       version = "0.5.8"
       source  = "Edgio/edgecast"
     }
   }

--- a/examples/resources/edgecast_edgecname/main.tf
+++ b/examples/resources/edgecast_edgecname/main.tf
@@ -4,7 +4,7 @@
 terraform {
   required_providers {
     edgecast = {
-       version = "0.5.7"
+       version = "0.5.8"
       source  = "Edgio/edgecast"
     }
   }

--- a/examples/resources/edgecast_origin/main.tf
+++ b/examples/resources/edgecast_origin/main.tf
@@ -4,7 +4,7 @@
 terraform {
   required_providers {
     edgecast = {
-       version = "0.5.7"
+       version = "0.5.8"
       source  = "Edgio/edgecast"
     }
   }

--- a/examples/resources/edgecast_rules_engine_policy/main.tf
+++ b/examples/resources/edgecast_rules_engine_policy/main.tf
@@ -4,7 +4,7 @@
 terraform {
   required_providers {
     edgecast = {
-       version = "0.5.7"
+       version = "0.5.8"
       source  = "Edgio/edgecast"
     }
   }

--- a/examples/resources/edgecast_waf_access_rule/main.tf
+++ b/examples/resources/edgecast_waf_access_rule/main.tf
@@ -1,7 +1,7 @@
 terraform {
   required_providers {
     edgecast = {
-      version = "0.5.7"
+      version = "0.5.8"
       source  = "Edgio/edgecast"
     }
   }

--- a/examples/resources/edgecast_waf_bot_rule_set/main.tf
+++ b/examples/resources/edgecast_waf_bot_rule_set/main.tf
@@ -1,7 +1,7 @@
 terraform {
   required_providers {
     edgecast = {
-       version = "0.5.7"
+       version = "0.5.8"
       source  = "Edgio/edgecast"
     }
   }

--- a/examples/resources/edgecast_waf_custom_rule_set/main.tf
+++ b/examples/resources/edgecast_waf_custom_rule_set/main.tf
@@ -1,7 +1,7 @@
 terraform {
   required_providers {
     edgecast = {
-       version = "0.5.7"
+       version = "0.5.8"
       source  = "Edgio/edgecast"
     }
   }

--- a/examples/resources/edgecast_waf_managed_rule/main.tf
+++ b/examples/resources/edgecast_waf_managed_rule/main.tf
@@ -1,7 +1,7 @@
 terraform {
   required_providers {
     edgecast = {
-       version = "0.5.7"
+       version = "0.5.8"
       source  = "Edgio/edgecast"
     }
   }

--- a/examples/resources/edgecast_waf_rate_rule/main.tf
+++ b/examples/resources/edgecast_waf_rate_rule/main.tf
@@ -1,7 +1,7 @@
 terraform {
   required_providers {
     edgecast = {
-       version = "0.5.7"
+       version = "0.5.8"
       source  = "Edgio/edgecast"
     }
   }

--- a/examples/resources/edgecast_waf_scopes/main.tf
+++ b/examples/resources/edgecast_waf_scopes/main.tf
@@ -1,7 +1,7 @@
 terraform {
   required_providers {
     edgecast = {
-       version = "0.5.7"
+       version = "0.5.8"
       source  = "Edgio/edgecast"
     }
   }

--- a/go.mod
+++ b/go.mod
@@ -6,7 +6,7 @@ module terraform-provider-edgecast
 go 1.18
 
 require (
-	github.com/EdgeCast/ec-sdk-go v0.1.22
+	github.com/EdgeCast/ec-sdk-go v0.1.23
 	github.com/go-test/deep v1.0.8
 	github.com/google/uuid v1.3.0
 	github.com/gruntwork-io/terratest v0.40.13

--- a/go.sum
+++ b/go.sum
@@ -41,8 +41,8 @@ cloud.google.com/go/storage v1.10.0/go.mod h1:FLPqc6j+Ki4BU591ie1oL6qBQGu2Bl/tZ9
 dmitri.shuralyov.com/gpu/mtl v0.0.0-20190408044501-666a987793e9/go.mod h1:H6x//7gZCb22OMCxBHrMx7a5I7Hp++hsVxbQ4BYO7hU=
 github.com/BurntSushi/toml v0.3.1/go.mod h1:xHWCNGjB5oqiDr8zfno3MHue2Ht5sIBksp03qcyfWMU=
 github.com/BurntSushi/xgb v0.0.0-20160522181843-27f122750802/go.mod h1:IVnqGOEym/WlBOVXweHU+Q+/VP0lqqI8lqeDx9IjBqo=
-github.com/EdgeCast/ec-sdk-go v0.1.22 h1:IsvXRZ/03sQ9lr/T4r1xYL0djTZBtGLKm/HYOTWLoyI=
-github.com/EdgeCast/ec-sdk-go v0.1.22/go.mod h1:neF8VXt4/XeqyzQL3pA1LctevGkSlnt/Rkdw9MmTYag=
+github.com/EdgeCast/ec-sdk-go v0.1.23 h1:fWgCI5P3tLFzHT07SizmF+iLGc0Xe8AlSzkzepqeJUE=
+github.com/EdgeCast/ec-sdk-go v0.1.23/go.mod h1:neF8VXt4/XeqyzQL3pA1LctevGkSlnt/Rkdw9MmTYag=
 github.com/Masterminds/goutils v1.1.0/go.mod h1:8cTjp+g8YejhMuvIA5y2vz3BpJxksy863GQaJW2MFNU=
 github.com/Masterminds/goutils v1.1.1 h1:5nUrii3FMTL5diU80unEVvNevw1nH4+ZV4DSLVJLSYI=
 github.com/Masterminds/goutils v1.1.1/go.mod h1:8cTjp+g8YejhMuvIA5y2vz3BpJxksy863GQaJW2MFNU=

--- a/install_win.bat
+++ b/install_win.bat
@@ -9,7 +9,7 @@ set HOSTNAME=github.com
 set NAMESPACE=terraform-providers
 set NAME=edgecast
 set BINARY=terraform-provider-%NAME%.exe
-set VERSION=0.5.7
+set VERSION=0.5.8
 set OS_ARCH=windows_amd64
 
 go build

--- a/test/integration/README.md
+++ b/test/integration/README.md
@@ -81,7 +81,7 @@ Within the newly-created directory, perform the following steps:
     terraform {
       required_providers {
         edgecast = {
-           version = "0.5.7"
+           version = "0.5.8"
           source  = "Edgio/edgecast"
         }
       }

--- a/test/integration/resources/customer/main.tf
+++ b/test/integration/resources/customer/main.tf
@@ -4,7 +4,7 @@
 terraform {
   required_providers {
     edgecast = {
-       version = "0.5.7"
+       version = "0.5.8"
       source  = "github.com/terraform-providers/edgecast"
     }
   }

--- a/test/integration/resources/customer_user/main.tf
+++ b/test/integration/resources/customer_user/main.tf
@@ -1,7 +1,7 @@
 terraform {
   required_providers {
     edgecast = {
-       version = "0.5.7"
+       version = "0.5.8"
       source  = "github.com/terraform-providers/edgecast"
     }
   }

--- a/test/integration/resources/dns_group/main.tf
+++ b/test/integration/resources/dns_group/main.tf
@@ -4,7 +4,7 @@
 terraform {
   required_providers {
     edgecast = {
-       version = "0.5.7"
+       version = "0.5.8"
       source  = "github.com/terraform-providers/edgecast"
     }
   }

--- a/test/integration/resources/dns_masterservergroup/main.tf
+++ b/test/integration/resources/dns_masterservergroup/main.tf
@@ -4,7 +4,7 @@
 terraform {
   required_providers {
     edgecast = {
-       version = "0.5.7"
+       version = "0.5.8"
       source  = "github.com/terraform-providers/edgecast"
     }
   }

--- a/test/integration/resources/dns_secondaryzonegroup/main.tf
+++ b/test/integration/resources/dns_secondaryzonegroup/main.tf
@@ -4,7 +4,7 @@
 terraform {
   required_providers {
     edgecast = {
-       version = "0.5.7"
+       version = "0.5.8"
       source  = "github.com/terraform-providers/edgecast"
     }
   }

--- a/test/integration/resources/dns_tsig/main.tf
+++ b/test/integration/resources/dns_tsig/main.tf
@@ -4,7 +4,7 @@
 terraform {
   required_providers {
     edgecast = {
-       version = "0.5.7"
+       version = "0.5.8"
       source  = "github.com/terraform-providers/edgecast"
     }
   }

--- a/test/integration/resources/dns_zone/main.tf
+++ b/test/integration/resources/dns_zone/main.tf
@@ -4,7 +4,7 @@
 terraform {
   required_providers {
     edgecast = {
-       version = "0.5.7"
+       version = "0.5.8"
       source  = "github.com/terraform-providers/edgecast"
     }
   }

--- a/test/integration/resources/edgecname/main.tf
+++ b/test/integration/resources/edgecname/main.tf
@@ -4,7 +4,7 @@
 terraform {
   required_providers {
     edgecast = {
-       version = "0.5.7"
+       version = "0.5.8"
       source  = "github.com/terraform-providers/edgecast"
     }
   }

--- a/test/integration/resources/origin/main.tf
+++ b/test/integration/resources/origin/main.tf
@@ -4,7 +4,7 @@
 terraform {
   required_providers {
     edgecast = {
-       version = "0.5.7"
+       version = "0.5.8"
       source  = "github.com/terraform-providers/edgecast"
     }
   }

--- a/test/integration/resources/rules_engine_policy/main.tf
+++ b/test/integration/resources/rules_engine_policy/main.tf
@@ -4,7 +4,7 @@
 terraform {
   required_providers {
     edgecast = {
-       version = "0.5.7"
+       version = "0.5.8"
       source  = "github.com/terraform-providers/edgecast"
     }
   }

--- a/test/integration/resources/waf_access_rule/main.tf
+++ b/test/integration/resources/waf_access_rule/main.tf
@@ -1,7 +1,7 @@
 terraform {
   required_providers {
     edgecast = {
-       version = "0.5.7"
+       version = "0.5.8"
       source  = "github.com/terraform-providers/edgecast"
     }
   }

--- a/test/integration/resources/waf_bot_rule_set/main.tf
+++ b/test/integration/resources/waf_bot_rule_set/main.tf
@@ -1,7 +1,7 @@
 terraform {
   required_providers {
     edgecast = {
-       version = "0.5.7"
+       version = "0.5.8"
       source  = "github.com/terraform-providers/edgecast"
     }
   }

--- a/test/integration/resources/waf_custom_rule_set/main.tf
+++ b/test/integration/resources/waf_custom_rule_set/main.tf
@@ -1,7 +1,7 @@
 terraform {
   required_providers {
     edgecast = {
-       version = "0.5.7"
+       version = "0.5.8"
       source  = "github.com/terraform-providers/edgecast"
     }
   }

--- a/test/integration/resources/waf_managed_rule/main.tf
+++ b/test/integration/resources/waf_managed_rule/main.tf
@@ -1,7 +1,7 @@
 terraform {
   required_providers {
     edgecast = {
-       version = "0.5.7"
+       version = "0.5.8"
       source  = "github.com/terraform-providers/edgecast"
     }
   }

--- a/test/integration/resources/waf_rate_rule/main.tf
+++ b/test/integration/resources/waf_rate_rule/main.tf
@@ -1,7 +1,7 @@
 terraform {
   required_providers {
     edgecast = {
-       version = "0.5.7"
+       version = "0.5.8"
       source  = "github.com/terraform-providers/edgecast"
     }
   }

--- a/test/integration/resources/waf_scopes/main.tf
+++ b/test/integration/resources/waf_scopes/main.tf
@@ -1,7 +1,7 @@
 terraform {
   required_providers {
     edgecast = {
-       version = "0.5.7"
+       version = "0.5.8"
       source  = "github.com/terraform-providers/edgecast"
     }
   }


### PR DESCRIPTION
1) Updating ec-sdk-go to v0.1.23
2) Update Terraform example files to v0.5.8 for new release