### PR TITLE
[SAS-1825] DNS Resource & Documentation Updates

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -31,6 +31,9 @@ unit-tests/**/credential_ucc.json
 .terraform/*
 **/*.copy
 docs_current/
+/*.tf
+/*.tfvars
+/*.tfstate
 
 .idea
 .env

--- a/Makefile
+++ b/Makefile
@@ -3,7 +3,7 @@ HOSTNAME=github.com
 NAMESPACE=terraform-providers
 NAME=edgecast
 BINARY=terraform-provider-${NAME}
-VERSION=1.3.3
+VERSION=1.3.4
 OS_ARCH=darwin_amd64
 
 default: install

--- a/README.md
+++ b/README.md
@@ -33,7 +33,7 @@ Reference this provider in a Terraform Configuration file (e.g. `main.tf`):
 terraform {
   required_providers {
     edgecast = {
-     version = "1.3.3"
+     version = "1.3.4"
       source  = "Edgio/edgecast"
     }
   }
@@ -121,7 +121,7 @@ Example:
 terraform {
   required_providers {
     edgecast = {
-     version = "1.3.3"
+     version = "1.3.4"
       source  = "Edgio/edgecast"
     }
   }
@@ -195,11 +195,6 @@ for more details on the type of token required, and how to acquire a token.
 Please refer to [the contributing.md file](Contributing.md) for information 
 about how to get involved. We welcome issues, questions, and pull requests.
 
-## Maintainers
-- Steven Paz: steven.paz@edgecast.com
-- Shikha Saluja: shikha.saluja@edgecast.com
-- Frank Contreras: frank.contreras@edgecast.com
-
 ## License
 This project is licensed under the terms of the [Apache 2.0](LICENSE) open 
 source license.
@@ -215,4 +210,4 @@ their inputs and outputs.
 
 [Examples](https://github.com/EdgeCast/terraform-provider-edgecast/tree/Master/examples) - Examples to get started can be found here.
 
-[Submit an Issue](https://github.com/EdgeCast/terraform-provider-edgecast/issues) - Found a bug? Want to request a feature? Please do so here.
+Found a bug? Want to request a feature? Please [contact us](https://www.edg.io/contact-support/).

--- a/Taskfile.yaml
+++ b/Taskfile.yaml
@@ -11,7 +11,7 @@ vars:
   NAMESPACE: terraform-providers
   NAME: edgecast
   BINARY: terraform-provider-{{.NAME}}
-  VERSION: 1.3.3
+  VERSION: 1.3.4
 
 
 includes:

--- a/docs/resources/cps_certificate.md
+++ b/docs/resources/cps_certificate.md
@@ -149,14 +149,13 @@ resource "edgecast_cps_certificate" "certificate_2" {
 Describes the certificate request's organization.  
 
     ->Do not specify an organization for DV certificates. (see [below for nested schema](#nestedblock--organization))
-- `validation_status` (Block Set) Retrieve status information for your certificate request. This includes certificate request status, certificate order status, organization validation status, and domain control validation (DCV) status. (see [below for nested schema](#nestedblock--validation_status))
 
 ### Read-Only
 
 - `created` (String) Indicates the timestamp at which this request for a certificate was initially submitted.  
 **Syntax:**  *YYYY*-*MM*-*DD*T*hh*:*mm*:*ss*.*ffffff*Z
-- `created_by` (Block Set) Describes the user that submitted this certificate request. (see [below for nested schema](#nestedblock--created_by))
-- `deployments` (Block Set) Returns a null value. (see [below for nested schema](#nestedblock--deployments))
+- `created_by` (Set of Object) Describes the user that submitted this certificate request. (see [below for nested schema](#nestedatt--created_by))
+- `deployments` (Set of Object) Returns a null value. (see [below for nested schema](#nestedatt--deployments))
 - `expiration_date` (String) Indicates the timestamp at which this certificate will expire.  
 **Syntax:**  *YYYY*-*MM*-*DD*T*hh*:*mm*:*ss*.*ffffff*Z  
 If the Certificate Authority (CA) is still processing the certificate request, then this argument returns the following timestamp:   
@@ -164,9 +163,10 @@ If the Certificate Authority (CA) is still processing the certificate request, t
 - `id` (String) Indicates the system-defined ID assigned to this certificate.
 - `last_modified` (String) Indicates the timestamp at which this request for a certificate was last modified.  
 **Syntax:**  *YYYY*-*MM*-*DD*T*hh*:*mm*:*ss*.*ffffff*Z
-- `modified_by` (Block Set) Returns a null value. (see [below for nested schema](#nestedblock--modified_by))
+- `modified_by` (Set of Object) Returns a null value. (see [below for nested schema](#nestedatt--modified_by))
 - `request_type` (String) Returns `Enterprise`.
 - `thumbprint` (String) Returns a null value.
+- `validation_status` (Set of Object) Retrieve status information for your certificate request. This includes certificate request status, certificate order status, organization validation status, and domain control validation (DCV) status. (see [below for nested schema](#nestedatt--validation_status))
 - `workflow_error_message` (String) Returns a null value.
 
 <a id="nestedblock--domain"></a>
@@ -280,91 +280,74 @@ Sets the title of the current contact.
 
 
 
-<a id="nestedblock--validation_status"></a>
-### Nested Schema for `validation_status`
-
-Optional:
-
-- `order_validation` (Block Set) Describes order status information for this certificate request. (see [below for nested schema](#nestedblock--validation_status--order_validation))
-
-Read-Only:
-
-- `error_message` (String) Indicates the reason why an error occurred. Returns a null value if an error has not occurred.
-- `requires_attention` (Boolean) Indicates whether this certificate request requires your attention before it can proceed to the next step.
-- `status` (String) Indicates the status for this certificate request.
-- `step` (Number) Indicates the order's current step in the certificate provisioning workflow.
-**Example:**  
-This argument returns `3` when a certificate order is currently in step 3. Domain Validation (DCV).
-
-<a id="nestedblock--validation_status--order_validation"></a>
-### Nested Schema for `validation_status.order_validation`
-
-Optional:
-
-- `domain_validation` (Block List) Contains the domains associated with this certificate request and their current Domain Control Validation (DCV) status. (see [below for nested schema](#nestedblock--validation_status--order_validation--domain_validation))
-
-Read-Only:
-
-- `organization_validation` (Block Set) Describes the requested certificate's validation level and its status. (see [below for nested schema](#nestedblock--validation_status--order_validation--organization_validation))
-- `status` (String) Indicates the status for this certificate order.
-
-<a id="nestedblock--validation_status--order_validation--domain_validation"></a>
-### Nested Schema for `validation_status.order_validation.domain_validation`
-
-Optional:
-
-- `domain_names` (List of String) Indicates the domain name.
-
-Read-Only:
-
-- `status` (String) Indicates the current Domain Control Validation (DCV) status for the domain identified within the `domain_names` list.  
-
-    -> Use the [edgecast_cps_validation_statuses data source](../data-sources/cps_validation_statuses) to retrieve a list of Domain Control Validation (DCV) statuses.
-
-
-<a id="nestedblock--validation_status--order_validation--organization_validation"></a>
-### Nested Schema for `validation_status.order_validation.organization_validation`
-
-Read-Only:
-
-- `status` (String) Indicates the organization validation status for EV and OV certificates.  Returns `NA` for DV certificates.  
-
-    -> Use the [edgecast_cps_validation_statuses data source](../data-sources/cps_validation_statuses) to retrieve a list of organization validation statuses.
-- `validation_type` (String) Indicates the validation level for the requested certificate.
-
-
-
-
-<a id="nestedblock--created_by"></a>
+<a id="nestedatt--created_by"></a>
 ### Nested Schema for `created_by`
 
 Read-Only:
 
-- `identity_id` (String) Reserved for future use.
-- `identity_type` (String) Reserved for future use. [ User, Client ]
-- `portal_type_id` (String) Reserved for future use. [ Customer, Partner, Wholesaler, Uber, OpenCdn ]
-- `user_id` (Number) Reserved for future use.
+- `identity_id` (String)
+- `identity_type` (String)
+- `portal_type_id` (String)
+- `user_id` (Number)
 
 
-<a id="nestedblock--deployments"></a>
+<a id="nestedatt--deployments"></a>
 ### Nested Schema for `deployments`
 
 Read-Only:
 
-- `delivery_region` (String) Indicates the name of the delivery region to which this certificate was deployed.
-- `hex_url` (String) Indicates the CDN domain through which requests for this certificate will be routed.
-- `platform` (String) Identifies the delivery platform (e.g., `HttpLarge`) associated with this certificate.
+- `delivery_region` (String)
+- `hex_url` (String)
+- `platform` (String)
 
 
-<a id="nestedblock--modified_by"></a>
+<a id="nestedatt--modified_by"></a>
 ### Nested Schema for `modified_by`
 
 Read-Only:
 
-- `identity_id` (String) Reserved for future use.
-- `identity_type` (String) Reserved for future use. [ User, Client ]
-- `portal_type_id` (String) Reserved for future use. [ Customer, Partner, Wholesaler, Uber, OpenCdn ]
-- `user_id` (Number) Reserved for future use. [ User, Client ]
+- `identity_id` (String)
+- `identity_type` (String)
+- `portal_type_id` (String)
+- `user_id` (Number)
+
+
+<a id="nestedatt--validation_status"></a>
+### Nested Schema for `validation_status`
+
+Read-Only:
+
+- `error_message` (String)
+- `order_validation` (Set of Object) (see [below for nested schema](#nestedobjatt--validation_status--order_validation))
+- `requires_attention` (Boolean)
+- `status` (String)
+- `step` (Number)
+
+<a id="nestedobjatt--validation_status--order_validation"></a>
+### Nested Schema for `validation_status.order_validation`
+
+Read-Only:
+
+- `domain_validation` (List of Object) (see [below for nested schema](#nestedobjatt--validation_status--order_validation--domain_validation))
+- `organization_validation` (Set of Object) (see [below for nested schema](#nestedobjatt--validation_status--order_validation--organization_validation))
+- `status` (String)
+
+<a id="nestedobjatt--validation_status--order_validation--domain_validation"></a>
+### Nested Schema for `validation_status.order_validation.domain_validation`
+
+Read-Only:
+
+- `domain_names` (List of String)
+- `status` (String)
+
+
+<a id="nestedobjatt--validation_status--order_validation--organization_validation"></a>
+### Nested Schema for `validation_status.order_validation.organization_validation`
+
+Read-Only:
+
+- `status` (String)
+- `validation_type` (String)
 
 ## Import Resource
 Manage an existing TLS certificate through Terraform by importing it as a resource. Perform the following steps:

--- a/docs/resources/dns_group.md
+++ b/docs/resources/dns_group.md
@@ -225,8 +225,6 @@ Required:
 						Please refer to the following URL for additional 
 						information:
 						https://developer.edgecast.com/cdn/api/Content/Media_Management/DNS/Get_A_HC_Types.htm
-- `content_verification` (String) Defines the text that will be used to 
-						verify the success of the health check.
 - `email_notification_address` (String) Defines the e-mail address to which 
 						health check notifications will be sent.
 - `failed_check_threshold` (Number) Defines the number of consecutive 
@@ -238,6 +236,8 @@ Required:
 
 Optional:
 
+- `content_verification` (String) Defines the text that will be used to 
+						verify the success of the health check.
 - `http_method_id` (Number) Defines an HTTP method by its 
 						system-defined ID. An HTTP method is only used by 
 						HTTP/HTTPs health checks. Supported values are: 
@@ -335,8 +335,6 @@ Required:
 						Please refer to the following URL for additional 
 						information:
 						https://developer.edgecast.com/cdn/api/Content/Media_Management/DNS/Get_A_HC_Types.htm
-- `content_verification` (String) Defines the text that will be used to 
-						verify the success of the health check.
 - `email_notification_address` (String) Defines the e-mail address to which 
 						health check notifications will be sent.
 - `failed_check_threshold` (Number) Defines the number of consecutive 
@@ -348,6 +346,8 @@ Required:
 
 Optional:
 
+- `content_verification` (String) Defines the text that will be used to 
+						verify the success of the health check.
 - `http_method_id` (Number) Defines an HTTP method by its 
 						system-defined ID. An HTTP method is only used by 
 						HTTP/HTTPs health checks. Supported values are: 
@@ -445,8 +445,6 @@ Required:
 						Please refer to the following URL for additional 
 						information:
 						https://developer.edgecast.com/cdn/api/Content/Media_Management/DNS/Get_A_HC_Types.htm
-- `content_verification` (String) Defines the text that will be used to 
-						verify the success of the health check.
 - `email_notification_address` (String) Defines the e-mail address to which 
 						health check notifications will be sent.
 - `failed_check_threshold` (Number) Defines the number of consecutive 
@@ -458,6 +456,8 @@ Required:
 
 Optional:
 
+- `content_verification` (String) Defines the text that will be used to 
+						verify the success of the health check.
 - `http_method_id` (Number) Defines an HTTP method by its 
 						system-defined ID. An HTTP method is only used by 
 						HTTP/HTTPs health checks. Supported values are: 

--- a/docs/resources/dns_zone.md
+++ b/docs/resources/dns_zone.md
@@ -280,8 +280,6 @@ Required:
 							4 - TCP SSL. Please refer to the following URL for 
 							additional information: 
 							https://developer.edgecast.com/cdn/api/Content/Media_Management/DNS/Get_A_HC_Types.htm
-- `content_verification` (String) Defines the text that will be used to 
-							verify the success of the health check.
 - `email_notification_address` (String) Defines the e-mail address to which 
 							health check notifications will be sent.
 - `failed_check_threshold` (Number) Defines the number of consecutive 
@@ -295,6 +293,8 @@ Required:
 
 Optional:
 
+- `content_verification` (String) Defines the text that will be used to 
+							verify the success of the health check.
 - `http_method_id` (Number) Defines an HTTP method by its 
 							system-defined ID. An HTTP method is only used by 
 							HTTP/HTTPs health checks. Supported values are: 
@@ -394,8 +394,6 @@ Required:
 							4 - TCP SSL. Please refer to the following URL for 
 							additional information: 
 							https://developer.edgecast.com/cdn/api/Content/Media_Management/DNS/Get_A_HC_Types.htm
-- `content_verification` (String) Defines the text that will be used to 
-							verify the success of the health check.
 - `email_notification_address` (String) Defines the e-mail address to which 
 							health check notifications will be sent.
 - `failed_check_threshold` (Number) Defines the number of consecutive 
@@ -409,6 +407,8 @@ Required:
 
 Optional:
 
+- `content_verification` (String) Defines the text that will be used to 
+							verify the success of the health check.
 - `http_method_id` (Number) Defines an HTTP method by its 
 							system-defined ID. An HTTP method is only used by 
 							HTTP/HTTPs health checks. Supported values are: 
@@ -508,8 +508,6 @@ Required:
 							4 - TCP SSL. Please refer to the following URL for 
 							additional information: 
 							https://developer.edgecast.com/cdn/api/Content/Media_Management/DNS/Get_A_HC_Types.htm
-- `content_verification` (String) Defines the text that will be used to 
-							verify the success of the health check.
 - `email_notification_address` (String) Defines the e-mail address to which 
 							health check notifications will be sent.
 - `failed_check_threshold` (Number) Defines the number of consecutive 
@@ -523,6 +521,8 @@ Required:
 
 Optional:
 
+- `content_verification` (String) Defines the text that will be used to 
+							verify the success of the health check.
 - `http_method_id` (Number) Defines an HTTP method by its 
 							system-defined ID. An HTTP method is only used by 
 							HTTP/HTTPs health checks. Supported values are: 

--- a/docs/resources/waf_botmanager.md
+++ b/docs/resources/waf_botmanager.md
@@ -26,7 +26,7 @@ This resource requires a [REST API token](../guides/authentication#rest-api-toke
 resource "edgecast_waf_botmanager" "botmanager_1" {
 
 	customer_id = "ABCDE"
-	name = "My Bot Manager updated"
+	name = "My Bot Manager"
 	bots_prod_id = "123bot1" # Must be an existing production Bot Rule
 	actions {
 		alert{

--- a/docs/resources/waf_scopes.md
+++ b/docs/resources/waf_scopes.md
@@ -117,13 +117,12 @@ resource "edgecast_waf_scopes" "scopes1" {
 
     rules_prod_id = "<Custom Rule ID>"
 
-    bots_prod_id = "<Bots Rule ID>"
+    bot_manager_config_id = "<Bot Manager Config ID>"
 
-    bots_prod_action {
-      name = "bots action"
-      enf_type = "BROWSER_CHALLENGE"
-      valid_for_sec = 60
-    }
+    recaptcha_action_name = "edgio_bot"
+    recaptcha_secret_key = "2Phg5FFFFFFFFFFFFFFFFFFFFFFFFFFFFFFF1vkF"
+    recaptcha_site_key = "6Lcm3XXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX5mfX"
+
   }
 
 }
@@ -153,8 +152,7 @@ Optional:
 - `acl_audit_id` (String) Indicates the system-defined ID for the access rule that will audit production traffic for this Security Application Manager configuration.
 - `acl_prod_action` (Block Set, Max: 1) Describes the type of action that will take place when the access rule defined within the `acl_prod_id` argument is violated. (see [below for nested schema](#nestedblock--scope--acl_prod_action))
 - `acl_prod_id` (String) Indicates the system-defined ID for the access rule that will be applied to production traffic for this Security Application Manager configuration.
-- `bots_prod_action` (Block Set, Max: 1) Describes the browser challenge that will be applied to requests that satisfy the bot rule set defined within the `bot_prod_id` argument. (see [below for nested schema](#nestedblock--scope--bots_prod_action))
-- `bots_prod_id` (String) Indicates the system-defined ID for the bots rule that will be applied to production traffic for this Security Application Manager configuration.
+- `bot_manager_config_id` (String) Indicates the system-defined ID for the bot manager that will be applied to production traffic for this Security Application Manager configuration.
 - `host` (Block Set, Max: 1) Describes a hostname match condition. (see [below for nested schema](#nestedblock--scope--host))
 - `limit` (Block List) Identifies the set of rate rules that will be enforced for this Security Application Manager configuration and the enforcement action that will be applied to rate limited requests. (see [below for nested schema](#nestedblock--scope--limit))
 - `name` (String) Indicates the name assigned to the Security Application Manager configuration.  
@@ -164,6 +162,9 @@ Optional:
 - `profile_audit_id` (String) Indicates the system-defined ID for the managed rule that will audit production traffic for this Security Application Manager configuration.
 - `profile_prod_action` (Block Set, Max: 1) Describes the type of action that will take place when the managed rule defined within the `profile_prod_id` property is violated. (see [below for nested schema](#nestedblock--scope--profile_prod_action))
 - `profile_prod_id` (String) Indicates the system-defined ID for the managed rule that will be applied to production traffic for this Security Application Manager configuration.
+- `recaptcha_action_name` (String) Indicates the name assigned to the action that will take place when the bot manager with recaptcha type defined within the BotManagerConfigId property is violated.
+- `recaptcha_secret_key` (String) Indicates the secret key assigned to the bot manager with recaptcha type defined within the BotManagerConfigId property.
+- `recaptcha_site_key` (String) Indicates the reCaptcha site key assigned to the bot manager with recaptcha type defined within the BotManagerConfigId property.
 - `rules_audit_action` (Block Set, Max: 1) Describes the type of action that will take place when the custom rule set defined within the `rules_audit_id` property is violated. (see [below for nested schema](#nestedblock--scope--rules_audit_action))
 - `rules_audit_id` (String) Indicates the system-defined ID for the custom rule set that will audit production traffic for this Security Application Manager configuration.
 - `rules_prod_action` (Block Set, Max: 1) Describes the type of action that will take place when the custom rule set defined within the `rules_prod_id` property is violated. (see [below for nested schema](#nestedblock--scope--rules_prod_action))
@@ -200,23 +201,6 @@ Optional:
 - `status` (Number) **acl_prod_action.type=CUSTOM_RESPONSE:** Indicates the HTTP status code (e.g., 404) for the custom response that will be sent to malicious traffic.
 - `url` (String) **acl_prod_action.type=REDIRECT_302:** Indicates the URL to which malicious requests will be redirected.
 - `valid_for_sec` (Number) Reserved for future use.
-
-
-<a id="nestedblock--scope--bots_prod_action"></a>
-### Nested Schema for `scope.bots_prod_action`
-
-Required:
-
-- `enf_type` (String) Set this property to `BROWSER_CHALLENGE`.
-
-Optional:
-
-- `name` (String) Indicates the name assigned to this enforcement action configuration.
-- `response_body_base64` (String) Reserved for future use.
-- `response_headers` (Map of String) Reserved for future use.
-- `status` (Number) Indicates the HTTP status code (e.g., 404) for the response provided to clients that are being served the browser challenge.
-- `url` (String) Reserved for future use.
-- `valid_for_sec` (Number) Indicates the number of minutes for which our CDN will serve content to a client that solves a browser challenge without requiring an additional browser challenge to be solved. Specify a value between 1 and 1,440 minutes.
 
 
 <a id="nestedblock--scope--host"></a>

--- a/edgecast/provider.go
+++ b/edgecast/provider.go
@@ -28,7 +28,7 @@ const (
 	idsURLProd       string = "https://id.vdms.io"
 
 	// Version indicates the current version of this provider
-	Version string = "1.3.3"
+	Version string = "1.3.4"
 
 	userAgentFormat = "edgecast/terraform-provider:%s"
 )

--- a/edgecast/resources/dnsroute/group.go
+++ b/edgecast/resources/dnsroute/group.go
@@ -55,10 +55,9 @@ func ResourceGroup() *schema.Resource {
 					},
 					"content_verification": {
 						Type:     schema.TypeString,
-						Required: true,
+						Optional: true,
 						Description: `Defines the text that will be used to 
 						verify the success of the health check.`,
-						ValidateFunc: validation.StringIsNotWhiteSpace,
 					},
 					"email_notification_address": {
 						Type:     schema.TypeString,

--- a/edgecast/resources/dnsroute/zone.go
+++ b/edgecast/resources/dnsroute/zone.go
@@ -58,10 +58,9 @@ func ResourceZone() *schema.Resource {
 						},
 						"content_verification": {
 							Type:     schema.TypeString,
-							Required: true,
+							Optional: true,
 							Description: `Defines the text that will be used to 
 							verify the success of the health check.`,
-							ValidateFunc: validation.StringIsNotWhiteSpace,
 						},
 						"email_notification_address": {
 							Type:     schema.TypeString,

--- a/examples/data-sources/edgecast_cps_dns_txt_token/main.tf
+++ b/examples/data-sources/edgecast_cps_dns_txt_token/main.tf
@@ -4,7 +4,7 @@
 terraform {
   required_providers {
     edgecast = {
-        version = "1.3.3"
+        version = "1.3.4"
         source  = "Edgio/edgecast"
     }
   }

--- a/examples/data-sources/edgecast_cps_full_workflow/main.tf
+++ b/examples/data-sources/edgecast_cps_full_workflow/main.tf
@@ -4,7 +4,7 @@
 terraform {
   required_providers {
     edgecast = {
-      version = "1.3.3"
+      version = "1.3.4"
       source  = "Edgio/edgecast"
     }
   }

--- a/examples/data-sources/edgecast_cps_target_cname/main.tf
+++ b/examples/data-sources/edgecast_cps_target_cname/main.tf
@@ -4,7 +4,7 @@
 terraform {
   required_providers {
     edgecast = {
-      version = "1.3.3"
+      version = "1.3.4"
       source  = "Edgio/edgecast"
     }
   }

--- a/examples/data-sources/edgecast_originv3_hostname_resolution_methods/main.tf
+++ b/examples/data-sources/edgecast_originv3_hostname_resolution_methods/main.tf
@@ -4,7 +4,7 @@
 terraform {
   required_providers {
     edgecast = {
-        version = "1.3.3"
+        version = "1.3.4"
         source  = "Edgio/edgecast"
     }
   }

--- a/examples/data-sources/edgecast_originv3_httplarge_datasource/main.tf
+++ b/examples/data-sources/edgecast_originv3_httplarge_datasource/main.tf
@@ -4,7 +4,7 @@
 terraform {
   required_providers {
     edgecast = {
-        version = "1.3.3"
+        version = "1.3.4"
         source  = "Edgio/edgecast"
     }
   }

--- a/examples/data-sources/edgecast_originv3_protocoltypes/main.tf
+++ b/examples/data-sources/edgecast_originv3_protocoltypes/main.tf
@@ -4,7 +4,7 @@
 terraform {
   required_providers {
     edgecast = {
-        version = "1.3.3"
+        version = "1.3.4"
         source  = "Edgio/edgecast"
     }
   }

--- a/examples/resources/edgecast_cps_appendix/main.tf
+++ b/examples/resources/edgecast_cps_appendix/main.tf
@@ -4,7 +4,7 @@
 terraform {
   required_providers {
     edgecast = {
-       version = "1.3.3"
+       version = "1.3.4"
         source  = "Edgio/edgecast"
     }
   }

--- a/examples/resources/edgecast_cps_certificate/main.tf
+++ b/examples/resources/edgecast_cps_certificate/main.tf
@@ -1,7 +1,7 @@
 terraform {
    required_providers {
     edgecast = {
-       version = "1.3.3"
+       version = "1.3.4"
         source  = "Edgio/edgecast"
     }
   }

--- a/examples/resources/edgecast_customer/main.tf
+++ b/examples/resources/edgecast_customer/main.tf
@@ -4,7 +4,7 @@
 terraform {
   required_providers {
     edgecast = {
-      version = "1.3.3"
+      version = "1.3.4"
       source  = "Edgio/edgecast"
     }
   }

--- a/examples/resources/edgecast_customer_user/main.tf
+++ b/examples/resources/edgecast_customer_user/main.tf
@@ -1,7 +1,7 @@
 terraform {
   required_providers {
     edgecast = {
-      version = "1.3.3"
+      version = "1.3.4"
       source  = "Edgio/edgecast"
     }
   }

--- a/examples/resources/edgecast_dns_group/main.tf
+++ b/examples/resources/edgecast_dns_group/main.tf
@@ -4,7 +4,7 @@
 terraform {
   required_providers {
     edgecast = {
-      version = "1.3.3"
+      version = "1.3.4"
       source  = "Edgio/edgecast"
     }
   }

--- a/examples/resources/edgecast_dns_masterservergroup/main.tf
+++ b/examples/resources/edgecast_dns_masterservergroup/main.tf
@@ -4,7 +4,7 @@
 terraform {
   required_providers {
     edgecast = {
-      version = "1.3.3"
+      version = "1.3.4"
       source  = "Edgio/edgecast"
     }
   }

--- a/examples/resources/edgecast_dns_secondaryzonegroup/main.tf
+++ b/examples/resources/edgecast_dns_secondaryzonegroup/main.tf
@@ -4,7 +4,7 @@
 terraform {
   required_providers {
     edgecast = {
-      version = "1.3.3"
+      version = "1.3.4"
       source  = "Edgio/edgecast"
     }
   }

--- a/examples/resources/edgecast_dns_tsig/main.tf
+++ b/examples/resources/edgecast_dns_tsig/main.tf
@@ -4,7 +4,7 @@
 terraform {
   required_providers {
     edgecast = {
-      version = "1.3.3"
+      version = "1.3.4"
       source  = "Edgio/edgecast"
     }
   }

--- a/examples/resources/edgecast_dns_zone/main.tf
+++ b/examples/resources/edgecast_dns_zone/main.tf
@@ -4,7 +4,7 @@
 terraform {
   required_providers {
     edgecast = {
-      version = "1.3.3"
+      version = "1.3.4"
       source  = "Edgio/edgecast"
     }
   }

--- a/examples/resources/edgecast_edgecname/main.tf
+++ b/examples/resources/edgecast_edgecname/main.tf
@@ -4,7 +4,7 @@
 terraform {
   required_providers {
     edgecast = {
-      version = "1.3.3"
+      version = "1.3.4"
       source  = "Edgio/edgecast"
     }
   }

--- a/examples/resources/edgecast_origin/main.tf
+++ b/examples/resources/edgecast_origin/main.tf
@@ -4,7 +4,7 @@
 terraform {
   required_providers {
     edgecast = {
-      version = "1.3.3"
+      version = "1.3.4"
       source  = "Edgio/edgecast"
     }
   }

--- a/examples/resources/edgecast_originv3_httplarge/main.tf
+++ b/examples/resources/edgecast_originv3_httplarge/main.tf
@@ -1,7 +1,7 @@
 terraform {
    required_providers {
     edgecast = {
-       version = "1.3.3"
+       version = "1.3.4"
        source  = "Edgio/edgecast"
     }
   }

--- a/examples/resources/edgecast_rules_engine_policy/main.tf
+++ b/examples/resources/edgecast_rules_engine_policy/main.tf
@@ -4,7 +4,7 @@
 terraform {
   required_providers {
     edgecast = {
-      version = "1.3.3"
+      version = "1.3.4"
       source  = "Edgio/edgecast"
     }
   }

--- a/examples/resources/edgecast_waf_access_rule/main.tf
+++ b/examples/resources/edgecast_waf_access_rule/main.tf
@@ -1,7 +1,7 @@
 terraform {
   required_providers {
     edgecast = {
-     version = "1.3.3"
+     version = "1.3.4"
       source  = "Edgio/edgecast"
     }
   }

--- a/examples/resources/edgecast_waf_bot_manager/main.tf
+++ b/examples/resources/edgecast_waf_bot_manager/main.tf
@@ -1,7 +1,7 @@
 terraform {
    required_providers {
     edgecast = {
-       version = "1.3.3"
+       version = "1.3.4"
         source  = "Edgio/edgecast"
     }
   }

--- a/examples/resources/edgecast_waf_bot_rule_set/main.tf
+++ b/examples/resources/edgecast_waf_bot_rule_set/main.tf
@@ -1,7 +1,7 @@
 terraform {
   required_providers {
     edgecast = {
-      version = "1.3.3"
+      version = "1.3.4"
       source  = "Edgio/edgecast"
     }
   }

--- a/examples/resources/edgecast_waf_custom_rule_set/main.tf
+++ b/examples/resources/edgecast_waf_custom_rule_set/main.tf
@@ -1,7 +1,7 @@
 terraform {
   required_providers {
     edgecast = {
-      version = "1.3.3"
+      version = "1.3.4"
       source  = "Edgio/edgecast"
     }
   }

--- a/examples/resources/edgecast_waf_managed_rule/main.tf
+++ b/examples/resources/edgecast_waf_managed_rule/main.tf
@@ -1,7 +1,7 @@
 terraform {
   required_providers {
     edgecast = {
-      version = "1.3.3"
+      version = "1.3.4"
       source  = "Edgio/edgecast"
     }
   }

--- a/examples/resources/edgecast_waf_rate_rule/main.tf
+++ b/examples/resources/edgecast_waf_rate_rule/main.tf
@@ -1,7 +1,7 @@
 terraform {
   required_providers {
     edgecast = {
-      version = "1.3.3"
+      version = "1.3.4"
       source  = "Edgio/edgecast"
     }
   }

--- a/examples/resources/edgecast_waf_scopes/main.tf
+++ b/examples/resources/edgecast_waf_scopes/main.tf
@@ -1,7 +1,7 @@
 terraform {
   required_providers {
     edgecast = {
-      version = "1.3.3"
+      version = "1.3.4"
       source  = "Edgio/edgecast"
     }
   }

--- a/install_win.bat
+++ b/install_win.bat
@@ -9,7 +9,7 @@ set HOSTNAME=github.com
 set NAMESPACE=terraform-providers
 set NAME=edgecast
 set BINARY=terraform-provider-%NAME%.exe
-set VERSION=1.3.3
+set VERSION=1.3.4
 set OS_ARCH=windows_amd64
 
 go build

--- a/test/integration/README.md
+++ b/test/integration/README.md
@@ -62,7 +62,7 @@ Within the newly-created directory, perform the following steps:
     terraform {
       required_providers {
         edgecast = {
-          version = "1.3.3"
+          version = "1.3.4"
           source  = "Edgio/edgecast"
         }
       }

--- a/test/integration/resources/cps_certificate/main.tf
+++ b/test/integration/resources/cps_certificate/main.tf
@@ -4,7 +4,7 @@
 terraform {
   required_providers {
     edgecast = {
-      version = "1.3.3"
+      version = "1.3.4"
       source  = "github.com/terraform-providers/edgecast"
     }
   }

--- a/test/integration/resources/customer/main.tf
+++ b/test/integration/resources/customer/main.tf
@@ -4,7 +4,7 @@
 terraform {
   required_providers {
     edgecast = {
-      version = "1.3.3"
+      version = "1.3.4"
       source  = "github.com/terraform-providers/edgecast"
     }
   }

--- a/test/integration/resources/customer_user/main.tf
+++ b/test/integration/resources/customer_user/main.tf
@@ -1,7 +1,7 @@
 terraform {
   required_providers {
     edgecast = {
-      version = "1.3.3"
+      version = "1.3.4"
       source  = "github.com/terraform-providers/edgecast"
     }
   }

--- a/test/integration/resources/dns_group/main.tf
+++ b/test/integration/resources/dns_group/main.tf
@@ -4,7 +4,7 @@
 terraform {
   required_providers {
     edgecast = {
-      version = "1.3.3"
+      version = "1.3.4"
       source  = "github.com/terraform-providers/edgecast"
     }
   }

--- a/test/integration/resources/dns_masterservergroup/main.tf
+++ b/test/integration/resources/dns_masterservergroup/main.tf
@@ -4,7 +4,7 @@
 terraform {
   required_providers {
     edgecast = {
-      version = "1.3.3"
+      version = "1.3.4"
       source  = "github.com/terraform-providers/edgecast"
     }
   }

--- a/test/integration/resources/dns_secondaryzonegroup/main.tf
+++ b/test/integration/resources/dns_secondaryzonegroup/main.tf
@@ -4,7 +4,7 @@
 terraform {
   required_providers {
     edgecast = {
-      version = "1.3.3"
+      version = "1.3.4"
       source  = "github.com/terraform-providers/edgecast"
     }
   }

--- a/test/integration/resources/dns_tsig/main.tf
+++ b/test/integration/resources/dns_tsig/main.tf
@@ -4,7 +4,7 @@
 terraform {
   required_providers {
     edgecast = {
-      version = "1.3.3"
+      version = "1.3.4"
       source  = "github.com/terraform-providers/edgecast"
     }
   }

--- a/test/integration/resources/dns_zone/main.tf
+++ b/test/integration/resources/dns_zone/main.tf
@@ -4,7 +4,7 @@
 terraform {
   required_providers {
     edgecast = {
-      version = "1.3.3"
+      version = "1.3.4"
       source  = "github.com/terraform-providers/edgecast"
     }
   }

--- a/test/integration/resources/edgecname/main.tf
+++ b/test/integration/resources/edgecname/main.tf
@@ -4,7 +4,7 @@
 terraform {
   required_providers {
     edgecast = {
-      version = "1.3.3"
+      version = "1.3.4"
       source  = "github.com/terraform-providers/edgecast"
     }
   }

--- a/test/integration/resources/origin/main.tf
+++ b/test/integration/resources/origin/main.tf
@@ -4,7 +4,7 @@
 terraform {
   required_providers {
     edgecast = {
-      version = "1.3.3"
+      version = "1.3.4"
       source  = "github.com/terraform-providers/edgecast"
     }
   }

--- a/test/integration/resources/originv3_httplarge/main.tf
+++ b/test/integration/resources/originv3_httplarge/main.tf
@@ -4,7 +4,7 @@
 terraform {
   required_providers {
     edgecast = {
-      version = "1.3.3"
+      version = "1.3.4"
       source  = "github.com/terraform-providers/edgecast"
     }
   }

--- a/test/integration/resources/rules_engine_policy/main.tf
+++ b/test/integration/resources/rules_engine_policy/main.tf
@@ -4,7 +4,7 @@
 terraform {
   required_providers {
     edgecast = {
-      version = "1.3.3"
+      version = "1.3.4"
       source  = "github.com/terraform-providers/edgecast"
     }
   }

--- a/test/integration/resources/waf_access_rule/main.tf
+++ b/test/integration/resources/waf_access_rule/main.tf
@@ -1,7 +1,7 @@
 terraform {
   required_providers {
     edgecast = {
-      version = "1.3.3"
+      version = "1.3.4"
       source  = "github.com/terraform-providers/edgecast"
     }
   }

--- a/test/integration/resources/waf_bot_manager/main.tf
+++ b/test/integration/resources/waf_bot_manager/main.tf
@@ -4,7 +4,7 @@
 terraform {
   required_providers {
     edgecast = {
-      version = "1.3.3"
+      version = "1.3.4"
       source  = "Edgio/edgecast"
     }
   }

--- a/test/integration/resources/waf_bot_rule_set/main.tf
+++ b/test/integration/resources/waf_bot_rule_set/main.tf
@@ -1,7 +1,7 @@
 terraform {
   required_providers {
     edgecast = {
-      version = "1.3.3"
+      version = "1.3.4"
       source  = "github.com/terraform-providers/edgecast"
     }
   }

--- a/test/integration/resources/waf_custom_rule_set/main.tf
+++ b/test/integration/resources/waf_custom_rule_set/main.tf
@@ -1,7 +1,7 @@
 terraform {
   required_providers {
     edgecast = {
-      version = "1.3.3"
+      version = "1.3.4"
       source  = "github.com/terraform-providers/edgecast"
     }
   }

--- a/test/integration/resources/waf_managed_rule/main.tf
+++ b/test/integration/resources/waf_managed_rule/main.tf
@@ -1,7 +1,7 @@
 terraform {
   required_providers {
     edgecast = {
-      version = "1.3.3"
+      version = "1.3.4"
       source  = "github.com/terraform-providers/edgecast"
     }
   }

--- a/test/integration/resources/waf_rate_rule/main.tf
+++ b/test/integration/resources/waf_rate_rule/main.tf
@@ -1,7 +1,7 @@
 terraform {
   required_providers {
     edgecast = {
-      version = "1.3.3"
+      version = "1.3.4"
       source  = "github.com/terraform-providers/edgecast"
     }
   }

--- a/test/integration/resources/waf_scopes/main.tf
+++ b/test/integration/resources/waf_scopes/main.tf
@@ -1,7 +1,7 @@
 terraform {
   required_providers {
     edgecast = {
-      version = "1.3.3"
+      version = "1.3.4"
       source  = "github.com/terraform-providers/edgecast"
     }
   }


### PR DESCRIPTION
1) Update DNS group and zone resources to not require 'content_verification' to be set when creating a health check
2) Update provider generated documentation to include these DNS group and zone changes, plus additional changes from previous provider releases.
3) Update readme with latest support contact information
4) Update provider version to 1.3.4 in preparation for publishing
5) Finally update .gitignore to exclude terraform files in provider root when testing